### PR TITLE
Improve educator focus and add Gemini integration

### DIFF
--- a/src/helpers/common/components/ProfileImage.tsx
+++ b/src/helpers/common/components/ProfileImage.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
-import { SectionValidator } from './ValidSectionRenderer';
+import { AiOutlineInfoCircle } from 'react-icons/ai';
+import Tooltip from '@mui/material/Tooltip';
 
 const RoundedImage = styled.img`
   border-radius: 50%;
@@ -17,11 +18,24 @@ export const ProfileImage = ({
   width?: string;
   imageWrapperClassname?: string;
 }) => {
+  const placeholder = (
+    <Tooltip title="Paste your LinkedIn picture URL in Basic > Contacts > Image URL">
+      <div
+        className="flex items-center justify-center bg-gray-200 text-gray-500"
+        style={{ borderRadius: '50%', border: '0.5px solid', height, width }}
+      >
+        <AiOutlineInfoCircle />
+      </div>
+    </Tooltip>
+  );
+
   return (
     <div className={imageWrapperClassname}>
-      <SectionValidator value={src}>
+      {src ? (
         <RoundedImage alt="Profile image" src={src} height={height} width={width} />
-      </SectionValidator>
+      ) : (
+        placeholder
+      )}
     </div>
   );
 };

--- a/src/helpers/constants/editor-data.ts
+++ b/src/helpers/constants/editor-data.ts
@@ -16,7 +16,20 @@ export const headers: {
   },
   education: { title: 'Education', component: EducationLayout },
   experience: { title: 'Experience', component: ExperienceLayout },
-  activities: { title: 'Activities', component: ActivitiesLayout },
-  volunteering: { title: 'Volunteering', component: VolunteeringLayout },
-  awards: { title: 'Awards', component: AwardsLayout },
+  'prof-development-activities': {
+    title: 'Professional Development Activities',
+    component: ActivitiesLayout,
+  },
+  'other-curricula-activities': {
+    title: 'Other-Curricula Activities',
+    component: ActivitiesLayout,
+  },
+  certification: {
+    title: 'Professional Certification',
+    component: VolunteeringLayout,
+  },
+  registration: {
+    title: 'Registration & Curricula Familiarity',
+    component: AwardsLayout,
+  },
 };

--- a/src/helpers/utils/gemini.ts
+++ b/src/helpers/utils/gemini.ts
@@ -1,0 +1,21 @@
+export const geminiGenerate = async (apiKey: string, prompt: string) => {
+  const res = await fetch(
+    `https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=${apiKey}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        contents: [{ parts: [{ text: prompt }] }],
+      }),
+    }
+  );
+
+  if (!res.ok) {
+    throw new Error('Failed to generate content');
+  }
+
+  const data = await res.json();
+  return (
+    data.candidates?.[0]?.content?.parts?.[0]?.text?.trim() ?? ''
+  );
+};

--- a/src/modules/builder/editor/modules/activities/ActivitiesLayout.tsx
+++ b/src/modules/builder/editor/modules/activities/ActivitiesLayout.tsx
@@ -17,12 +17,12 @@ export interface IAllActivityTabs {
 const allActivityTabs: IAllActivityTabs = {
   involvements: {
     key: 'involvements',
-    label: 'Involvements',
+    label: 'Professional Development Activities',
     component: Involvements,
   },
   achievements: {
     key: 'achievements',
-    label: 'Achievements',
+    label: 'Other-Curricula Activities',
     component: Achievements,
   },
 };

--- a/src/modules/builder/editor/modules/activities/components/Achievements.tsx
+++ b/src/modules/builder/editor/modules/activities/components/Achievements.tsx
@@ -6,7 +6,7 @@ const Achievements = () => {
   const activities = useActivity((state) => state.activities);
   return (
     <RichtextEditor
-      label="Achievements"
+      label="Other Curricula Activities"
       value={activities.achievements}
       onChange={(htmlOutput) => {
         useActivity.getState().updateAchievements(htmlOutput);

--- a/src/modules/builder/editor/modules/activities/components/Involvements.tsx
+++ b/src/modules/builder/editor/modules/activities/components/Involvements.tsx
@@ -6,7 +6,7 @@ const Involvements = () => {
   const activities = useActivity((state) => state.activities);
   return (
     <RichtextEditor
-      label="Involvements"
+      label="Professional Development Activities"
       value={activities.involvements}
       onChange={(htmlOutput) => {
         useActivity.getState().updateInvolvements(htmlOutput);

--- a/src/modules/builder/editor/modules/awards/AwardsLayout.tsx
+++ b/src/modules/builder/editor/modules/awards/AwardsLayout.tsx
@@ -27,7 +27,7 @@ const AwardsLayout = () => {
       {allAwards.map((award, index) => (
         <MoveEditSection
           key={award.id}
-          title={award.title || 'Award'}
+          title={award.title || 'Registration'}
           expanded={expanded === award.id}
           length={allAwards.length}
           index={index}

--- a/src/modules/builder/editor/modules/awards/components/AddAward.tsx
+++ b/src/modules/builder/editor/modules/awards/components/AddAward.tsx
@@ -29,7 +29,7 @@ const AddAward = ({
 
   const buttonCaption = useMemo(() => {
     if (isEmpty) {
-      return '+ Add an award';
+      return '+ Add registration or curricula item';
     } else {
       return '+ Add more';
     }

--- a/src/modules/builder/editor/modules/awards/components/Award.tsx
+++ b/src/modules/builder/editor/modules/awards/components/Award.tsx
@@ -50,7 +50,7 @@ const AwardComp: React.FC<IAwardComp> = ({ awardInfo, currentIndex }) => {
   return (
     <Fragment>
       <TextField
-        label="Award name"
+        label="Registration or curricula"
         variant="filled"
         value={awardInfo.title}
         onChange={(e: ChangeEvent<HTMLInputElement>) => {
@@ -64,7 +64,7 @@ const AwardComp: React.FC<IAwardComp> = ({ awardInfo, currentIndex }) => {
         sx={{ marginBottom: '26px' }}
       />
       <TextField
-        label="Awarded by"
+        label="Issuing body"
         variant="filled"
         value={awardInfo.awarder}
         onChange={(e: ChangeEvent<HTMLInputElement>) => {
@@ -94,7 +94,7 @@ const AwardComp: React.FC<IAwardComp> = ({ awardInfo, currentIndex }) => {
         }}
       />
       <RichtextEditor
-        label="About the award"
+        label="Details"
         value={awardInfo.summary}
         onChange={onSummaryChange}
         name="summary"

--- a/src/modules/builder/editor/modules/basic/components/About.tsx
+++ b/src/modules/builder/editor/modules/basic/components/About.tsx
@@ -1,6 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { Fragment } from 'react';
 import { RichtextEditor } from '@/helpers/common/components/richtext';
+import { OutlinedButton } from '@/helpers/common/atoms/Buttons';
+import { geminiGenerate } from '@/helpers/utils/gemini';
+import { useGemini } from '@/stores/gemini';
 
 const About = ({
   basicTabs,
@@ -9,6 +12,31 @@ const About = ({
   basicTabs: any;
   onChangeHandler: (value: any, key: string) => void;
 }) => {
+  const apiKey = useGemini((state) => state.apiKey);
+
+  const generateSummary = async () => {
+    if (!apiKey) {
+      alert('Please set the Gemini API key in the menu.');
+      return;
+    }
+    const text = await geminiGenerate(
+      apiKey,
+      `Rewrite this summary for an educator's CV, highlighting teaching expertise and classroom achievements: ${basicTabs.summary}`
+    );
+    if (text) onChangeHandler(text, 'summary');
+  };
+
+  const generateObjective = async () => {
+    if (!apiKey) {
+      alert('Please set the Gemini API key in the menu.');
+      return;
+    }
+    const text = await geminiGenerate(
+      apiKey,
+      `Rewrite this career objective for an educator's CV, focusing on curriculum development and student outcomes: ${basicTabs.objective}`
+    );
+    if (text) onChangeHandler(text, 'objective');
+  };
   return (
     <Fragment>
       <RichtextEditor
@@ -19,6 +47,7 @@ const About = ({
         }}
         name="summary"
       />
+      <OutlinedButton onClick={generateSummary}>Generate with AI</OutlinedButton>
       <RichtextEditor
         label="Career objective"
         value={basicTabs.objective}
@@ -27,6 +56,7 @@ const About = ({
         }}
         name="objective"
       />
+      <OutlinedButton onClick={generateObjective}>Generate with AI</OutlinedButton>
     </Fragment>
   );
 };

--- a/src/modules/builder/editor/modules/basic/components/Contacts.tsx
+++ b/src/modules/builder/editor/modules/basic/components/Contacts.tsx
@@ -1,6 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { ChangeEvent, Fragment } from 'react';
 import TextField from '@mui/material/TextField';
+import InputAdornment from '@mui/material/InputAdornment';
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
+import { AiOutlineInfoCircle } from 'react-icons/ai';
 
 const Contacts = ({
   basicTabs,
@@ -25,6 +29,17 @@ const Contacts = ({
         value={basicTabs.image}
         onChange={(event: ChangeEvent<HTMLInputElement>) => {
           onChangeHandler(event.target.value, 'image');
+        }}
+        InputProps={{
+          endAdornment: (
+            <InputAdornment position="end">
+              <Tooltip title="Right-click your LinkedIn profile picture, copy the image address, and paste it here">
+                <IconButton size="small">
+                  <AiOutlineInfoCircle />
+                </IconButton>
+              </Tooltip>
+            </InputAdornment>
+          ),
         }}
       />
       <TextField

--- a/src/modules/builder/editor/modules/volunteering/VolunteeringLayout.tsx
+++ b/src/modules/builder/editor/modules/volunteering/VolunteeringLayout.tsx
@@ -27,7 +27,7 @@ const VolunteeringLayout = () => {
       {allVolunteeringExps.map((volunteeringInfo, index) => (
         <MoveEditSection
           key={volunteeringInfo.id}
-          title={volunteeringInfo.organization || 'Experience'}
+          title={volunteeringInfo.organization || 'Certification'}
           expanded={expanded === volunteeringInfo.id}
           length={allVolunteeringExps.length}
           index={index}

--- a/src/modules/builder/editor/modules/volunteering/components/AddVolunteering.tsx
+++ b/src/modules/builder/editor/modules/volunteering/components/AddVolunteering.tsx
@@ -33,7 +33,7 @@ const AddVolunteeringExp = ({
 
   const buttonCaption = useMemo(() => {
     if (isEmpty) {
-      return '+ Add a volunteering experience';
+      return '+ Add a certification';
     } else {
       return '+ Add more';
     }

--- a/src/modules/builder/editor/modules/volunteering/components/Volunteer.tsx
+++ b/src/modules/builder/editor/modules/volunteering/components/Volunteer.tsx
@@ -61,7 +61,7 @@ const Volunteer: React.FC<IVolunteerProps> = ({ volunteeringInfo, currentIndex }
   return (
     <Fragment>
       <TextField
-        label="Organisation"
+        label="Certification"
         variant="filled"
         value={volunteeringInfo.organization}
         onChange={(e: ChangeEvent<HTMLInputElement>) => {
@@ -75,7 +75,7 @@ const Volunteer: React.FC<IVolunteerProps> = ({ volunteeringInfo, currentIndex }
         sx={{ marginBottom: '26px' }}
       />
       <TextField
-        label="Role"
+        label="Issued by"
         variant="filled"
         value={volunteeringInfo.position}
         onChange={(e: ChangeEvent<HTMLInputElement>) => {
@@ -88,7 +88,7 @@ const Volunteer: React.FC<IVolunteerProps> = ({ volunteeringInfo, currentIndex }
         sx={{ marginBottom: '26px' }}
       />
       <DatePicker
-        label="Start date"
+        label="Issue date"
         value={dayjs(volunteeringInfo.startDate)}
         onChange={(newDate) => {
           onChangeHandler('startDate', newDate);
@@ -99,14 +99,14 @@ const Volunteer: React.FC<IVolunteerProps> = ({ volunteeringInfo, currentIndex }
         }}
       />
       <SwitchWidget
-        label={'I currently volunteer here'}
+        label={'This certification does not expire'}
         value={volunteeringInfo.isVolunteeringNow ?? false}
         onChange={(newValue: boolean) => {
           onChangeHandler('isVolunteeringNow', newValue);
         }}
       />
       <DatePicker
-        label="End date"
+        label="Expiry date"
         value={volunteeringInfo.isVolunteeringNow ? null : dayjs(volunteeringInfo.endDate)}
         onChange={(newDate) => {
           onChangeHandler('endDate', newDate);
@@ -124,7 +124,7 @@ const Volunteer: React.FC<IVolunteerProps> = ({ volunteeringInfo, currentIndex }
         disabled={volunteeringInfo.isVolunteeringNow}
       />
       <RichtextEditor
-        label="Few points on this volunteering experience"
+        label="Few details about this certification"
         value={volunteeringInfo.summary}
         onChange={onSummaryChange}
         name="summary"

--- a/src/modules/builder/nav-bar/NavBarLayout.tsx
+++ b/src/modules/builder/nav-bar/NavBarLayout.tsx
@@ -27,6 +27,7 @@ import { useEducations } from '@/stores/education';
 import { useExperiences } from '@/stores/experience';
 import { useVoluteeringStore } from '@/stores/volunteering';
 import { Menu, MenuItem } from '@mui/material';
+import GeminiKeyDialog from './components/GeminiKeyDialog';
 
 const TOTAL_TEMPLATES_AVAILABLE = Object.keys(AVAILABLE_TEMPLATES).length;
 
@@ -34,6 +35,7 @@ const NavBarLayout = () => {
   const [openToast, setOpenToast] = useState(false);
   const [menuAnchor, setMenuAnchor] = useState<null | HTMLElement>(null);
   const fileInputRef = useRef(null);
+  const [geminiDialogOpen, setGeminiDialogOpen] = useState(false);
 
   const handleMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
     setMenuAnchor(event.currentTarget);
@@ -164,6 +166,9 @@ const NavBarLayout = () => {
                 onChange={handleFileChange}
               />
             </StyledButton>
+            <StyledButton variant="text" onClick={() => setGeminiDialogOpen(true)}>
+              Gemini Key
+            </StyledButton>
             <PrintResume />
           </NavBarActions>
         </div>
@@ -207,6 +212,14 @@ const NavBarLayout = () => {
             onChange={handleFileChange}
           />
         </MenuItem>
+        <MenuItem
+          onClick={() => {
+            setGeminiDialogOpen(true);
+            handleMenuClose();
+          }}
+        >
+          Gemini Key
+        </MenuItem>
         <PrintResume isMenuButton />
       </Menu>
       <Toast
@@ -215,6 +228,10 @@ const NavBarLayout = () => {
           setOpenToast(false);
         }}
         content={'Resume data was successfully imported.'}
+      />
+      <GeminiKeyDialog
+        open={geminiDialogOpen}
+        onClose={() => setGeminiDialogOpen(false)}
       />
     </nav>
   );

--- a/src/modules/builder/nav-bar/components/GeminiKeyDialog.tsx
+++ b/src/modules/builder/nav-bar/components/GeminiKeyDialog.tsx
@@ -1,0 +1,44 @@
+import { Dialog, DialogActions, DialogContent, DialogTitle, TextField } from '@mui/material';
+import { OutlinedButton, TextButton } from '@/helpers/common/atoms/Buttons';
+import { useGemini } from '@/stores/gemini';
+import { useState, useEffect } from 'react';
+
+const GeminiKeyDialog = ({ open, onClose }: { open: boolean; onClose: () => void }) => {
+  const apiKey = useGemini((state) => state.apiKey);
+  const setApiKey = useGemini((state) => state.setApiKey);
+  const [value, setValue] = useState(apiKey);
+
+  useEffect(() => {
+    if (open) {
+      setValue(apiKey);
+    }
+  }, [apiKey, open]);
+
+  const handleSave = () => {
+    setApiKey(value.trim());
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle>Gemini API Key</DialogTitle>
+      <DialogContent>
+        <TextField
+          label="API Key"
+          variant="filled"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          autoComplete="off"
+          fullWidth
+          autoFocus
+        />
+      </DialogContent>
+      <DialogActions>
+        <OutlinedButton onClick={handleSave}>Save</OutlinedButton>
+        <TextButton onClick={onClose}>Cancel</TextButton>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default GeminiKeyDialog;

--- a/src/modules/builder/resume/ResumeLayout.tsx
+++ b/src/modules/builder/resume/ResumeLayout.tsx
@@ -7,7 +7,6 @@ import { useTemplates } from '@/stores/useTemplate';
 import { useThemes } from '@/stores/themes';
 import { useZoom } from '@/stores/useZoom';
 
-// TODO: need to define types
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export let StateContext: Context<any> = createContext(null);
 

--- a/src/stores/gemini.ts
+++ b/src/stores/gemini.ts
@@ -1,0 +1,19 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+interface IGeminiStore {
+  apiKey: string;
+  setApiKey: (key: string) => void;
+  reset: () => void;
+}
+
+export const useGemini = create<IGeminiStore>()(
+  persist(
+    (set) => ({
+      apiKey: '',
+      setApiKey: (key: string) => set({ apiKey: key }),
+      reset: () => set({ apiKey: '' }),
+    }),
+    { name: 'gemini-api-key' }
+  )
+);

--- a/src/templates/professional/components/AboutMe.tsx
+++ b/src/templates/professional/components/AboutMe.tsx
@@ -11,14 +11,12 @@ export default function AboutMe({
 }) {
   return (
     <div className="text-[1em]">
-      {profileImage.length !== 0 && (
-        <ProfileImage
-          src={profileImage}
-          width={'80px'}
-          height={'80px'}
-          imageWrapperClassname={`float-left mr-3 mb-1 ${styles.imageWrapShape}`}
-        />
-      )}
+      <ProfileImage
+        src={profileImage}
+        width={'80px'}
+        height={'80px'}
+        imageWrapperClassname={`float-left mr-3 mb-1 ${styles.imageWrapShape}`}
+      />
       <HTMLRenderer htmlString={summary} />
     </div>
   );


### PR DESCRIPTION
## Summary
- add tooltip instructions on image upload field
- show placeholder icon when no profile image is set
- tweak Gemini prompts for educator focus and add Generate buttons
- introduce Gemini API key dialog and store
- rename activity/volunteer/award sections for education professionals
- remove obsolete TODO comment

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684257381c6c8323a3ce47ad8b4362b3